### PR TITLE
Change output JSON bitstream filename

### DIFF
--- a/ebrick_fpga_cad/tools/fasm_to_bitstream/bitstream_finish.py
+++ b/ebrick_fpga_cad/tools/fasm_to_bitstream/bitstream_finish.py
@@ -29,7 +29,7 @@ def run(chip):
     bitstream_maps = chip.find_files('fpga', part_name, 'file', 'bitstream_map')
 
     if len(bitstream_maps) == 1:
-        json_outfile = f"outputs/{topmodule}_bitstream.json"
+        json_outfile = f"outputs/{topmodule}.json"
         config_bitstream = fasm_utils.fasm2bitstream(fasm_file, bitstream_maps[0])
         fasm_utils.write_bitstream_json(config_bitstream, json_outfile)
     elif len(bitstream_maps) == 0:


### PR DESCRIPTION
The intent in making this change is to enable the JSON file to be findable with `chip.find_result()`, which will only return results with names <design_name>.<extension>.  Does this change also just generally make the flow more adherent to general SC philosophy?