### PR TITLE
Part driver update

### DIFF
--- a/ebrick_fpga_cad/fpgas/ebrick_fpga_demo.py
+++ b/ebrick_fpga_cad/fpgas/ebrick_fpga_demo.py
@@ -49,7 +49,7 @@ def setup(chip):
         fpga.add('fpga', part_name, 'var', 'feature_set', 'enable')
 
         fpga.add('fpga', part_name, 'var', 'vpr_clock_model', 'route')
-        
+
         cad_root = os.path.join(f'{part_name}_cad', 'cad')
         fpga.set('fpga', part_name, 'file', 'archfile',
                  os.path.join(cad_root, 'ebrick_fpga_core.xml'))


### PR DESCRIPTION
Local testing was able to demonstrate that the pytest suite fails with the specified branch of SC and an incorrect clock model specification.  This failure should be reproducible by running the regression on commit ID 9ff1fdf if we are so inclined.