### PR TITLE
Improve instructions for emulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,41 +78,8 @@ cd examples/adder
 python3 adder.py
 ```
 
-## Running a Bitstream with Cloud Emulation
-
-To test out a bitstream with our web-based emulation tool, try running the hello world example in [examples/umi_hello](examples/umi_hello).  In that example, RTL implemented on ebrick-fpga sends a hello world message as a sequence of characters to an address that causes the characters to be printed out when run in an emulation environment.
-
-As with the adder example, first build a bitstream:
-
-```console
-cd examples/umi_hello
-```
-
-```console
-python3 umi_hello.py
-```
-
-Then:
-1. In a web browser, go to [https://preview.zeroasic.com/emulation](https://preview.zeroasic.com/emulation).  (TODO: replace with non-preview URL)
-2. Log in if necessary (menu in the upper right corner)
-3. Under "Select a Demo" on the left side of the window, click "FPGA"
-4. Click "Suggest Layout"
-5. In the middle of the page, click "Emulate"
-6. Wait for the Linux Terminal to display a prompt.  (may take a few minutes)
-7. Copy-paste the following command into the Linux Terminal and run it to fix the `init-fpga.sh` script (TODO: remove the need for this)
-```console
-head -n 14 /usr/bin/init-fpga.sh > temp && echo "sudo gridrw \$FPGA_LOC chiplet 0x4000000000 l 0
-sudo gridrw \$FPGA_LOC chiplet 0x1000000000 l 0
-sudo gridrw \$FPGA_LOC chiplet 0x1000000000 l 1
-sudo gridrw \$FPGA_LOC chiplet 0x4000000000 l 1" >> temp && sudo mv temp /usr/bin/init-fpga.sh && sudo chmod +x /usr/bin/init-fpga.sh
-```
-8. Click "Upload File" and select `ebrick-fpga-cad/examples/umi_hello/build/umi_hello/job0/bitstream/0/outputs/umi_hello.dat` (this is the bitstream you just built)
-9. Wait for the status bar to indicate that the file upload was successful.  (should take 5-10 seconds)
-10. In the Linux Terminal shell, type `init-fpga.sh` (this script is in the `PATH`, so no need to `cd` anywhere)
-11. Scroll down to the Output Terminal.  You should see the text `Hello World!` appear in a few seconds, if it's not already there.
-
-Suggested next step: try modifying the hello world string in `ebrick-fpga-cad/examples/umi_hello/rtl/umi_hello.v`, rebuild the bitstream, and go through steps 8-11 (i.e., from uploading the bitstream onwards) to run the new bitstream. 
-
+The resulting bitstream is located at `build/adder/job0/bitstream/0/outputs/adder.dat`.  To it test out with our web-based emulation tool, head over to [https://www.zeroasic.com/emulation#run](https://www.zeroasic.com/emulation#run).  Click the "FPGA" tab under "Select a Demo" (left side of the window) and follow the instructions provided there.
+ 
 ## Additional Examples and Documentation
 
 To run additional examples and learn more about the flow, please consult the user guide built in the repository setup step; this can be accessed by opening


### PR DESCRIPTION
This PR removes the readme section about running the `umi_hello` example with the web emulation tool, instead letting users know that they can take the bitstream generated for the `adder` example to zeroasic.com and follow the instructions there.  This improves several things:

1. Gives a single, simple example on the front page (`adder`).  This is possible with the new `fpga-gpio-set` and `fpga-gpio-get` commands in the web app, which provide a mechanism for interacting with FPGA designs that connect directly to GPIO pins (no UMI involved in user RTL)
2. No mini vs. full architecture distinction made on the front page readme.  This is possible because the web app now supports the full architecture.
3. Web-app specific instructions are removed from the front page, keeping the focus on the FPGA toolchain.

For now, if you want to test out the instructions, go to the preview site instead of the public link in the readme.