### PR TITLE
Bring umi_hello up to date

### DIFF
--- a/examples/umi_hello/constraints/pin_constraints.py
+++ b/examples/umi_hello/constraints/pin_constraints.py
@@ -4,7 +4,7 @@ import argparse
 import json
 import os
 
-from ebrick_fpga_cad.templates.ebrick_fpga_demo.umi_pin_constraints \
+from logik.templates.logik_demo.umi_pin_constraints \
     import generate_umi_pin_constraints
 
 
@@ -14,7 +14,7 @@ def main():
     option_parser.add_argument(
         "part_name",
         nargs='?',
-        default="ebrick_fpga_demo_mini",
+        default="logik_demo",
         help="specify part number to prep, or specify all to build all parts in parts catalog"
     )
 
@@ -33,7 +33,7 @@ def generate_mapped_constraints(part_name):
 
     pin_constraints = {}
 
-    if (part_name == 'ebrick_fpga_demo_mini'):
+    if (part_name == 'logik_demo'):
         pin_constraints["clk"] = {
             "direction": 'input',
             "pin": 'clk[0]'
@@ -41,7 +41,7 @@ def generate_mapped_constraints(part_name):
 
         pin_constraints["nreset"] = {
             "direction": 'input',
-            "pin": 'gpio_in[48]'
+            "pin": 'gpio_in[0]'
         }
 
         pin_constraints.update(

--- a/examples/umi_hello/constraints/pin_constraints_logik_demo.json
+++ b/examples/umi_hello/constraints/pin_constraints_logik_demo.json
@@ -5,7 +5,7 @@
   },
   "nreset": {
     "direction": "input",
-    "pin": "gpio_in[48]"
+    "pin": "gpio_in[0]"
   },
   "uhost_req_valid": {
     "direction": "output",

--- a/examples/umi_hello/umi_hello.py
+++ b/examples/umi_hello/umi_hello.py
@@ -10,7 +10,7 @@ def setup(chip, part_name=None):
     # 1. Defining the project
     # Set default part name
     if not part_name:
-        part_name = 'logik_demo_mini'
+        part_name = 'logik_demo'
     chip.set('fpga', 'partname', part_name, clobber=False)
     part_name = chip.get('fpga', 'partname')
 


### PR DESCRIPTION
* Change architecture from `logik_demo_mini` -> `logik_demo` so that it can run in the ZA emulation portal
* Get the constraints generator running again with the new project structure / naming
* Move the reset pin assignment from GPIO 48 -> GPIO 0 so that it is a little easier to use.  (set GPIO bus to 0 to reset, set GPIO bus to 1 to release from reset)