### PR TITLE
Add device codes to part driver

### DIFF
--- a/logik/fpgas/logik_demo.py
+++ b/logik/fpgas/logik_demo.py
@@ -47,7 +47,7 @@ def setup():
 
         # Set a variable for VPR to use to detect the correct <fixed_layout> section
         # of the architecture XML file
-        fpga.set('fpga', part_name, 'var', 'device_code', part_name)
+        fpga.set('fpga', part_name, 'var', 'vpr_device_code', part_name)
 
         fpga.set('fpga', part_name, 'lutsize', lut_size)
         fpga.add('fpga', part_name, 'var', 'feature_set', 'async_reset')

--- a/logik/fpgas/logik_demo.py
+++ b/logik/fpgas/logik_demo.py
@@ -45,6 +45,10 @@ def setup():
 
         fpga.set('fpga', part_name, 'vendor', vendor)
 
+        # Set a variable for VPR to use to detect the correct <fixed_layout> section
+        # of the architecture XML file
+        fpga.set('fpga', part_name, 'var', 'device_code', part_name)
+
         fpga.set('fpga', part_name, 'lutsize', lut_size)
         fpga.add('fpga', part_name, 'var', 'feature_set', 'async_reset')
         fpga.add('fpga', part_name, 'var', 'feature_set', 'async_set')


### PR DESCRIPTION
Companion PR for logik to https://github.com/siliconcompiler/siliconcompiler/pull/2914

I have opted to not yet update the SC version requirement, as the proposed change has been verified as backward compatible.  See https://github.com/zeroasiccorp/logik/actions/runs/11404439100