### PR TITLE
Update pyproject.toml SC dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 urls = {Homepage = "https://github.com/zeroasiccorp/logik"}
 requires-python = ">= 3.8"
 dependencies = [
-    "siliconcompiler >= 0.27.0",
+    "siliconcompiler >= 0.31.1",
 ]
 license = {file = "LICENSE"}
 dynamic = ["version"]


### PR DESCRIPTION
Motivation:  this will effectively move the required VPR version of logik to VPR 9.

@gadfort now that chip.summary() spawns a webpage, we'll need either eliminate chip.summary() calls from the regression tests or provide some hook in the examples to turn this off for true batch mode execution.  Feel free to add to the branch directly or propose a change here in comments.